### PR TITLE
feat(overview): add overview query for dashboard

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -107,10 +107,36 @@ onClientCallback('ox_banking:getDashboardData', async (playerId): Promise<Dashbo
   const account = await GetPlayer(playerId)?.getAccount();
 
   if (!account) return;
-
+  
+  const overview = await oxmysql.rawExecute<{
+    day: string;
+    income: number;
+    expenses: number;
+  }[]>(
+    `
+    SELECT 
+      DAYNAME(d.date) as day,
+      COALESCE(SUM(CASE WHEN at.toId = ? THEN at.amount ELSE 0 END), 0) as income,
+      COALESCE(SUM(CASE WHEN at.fromId = ? THEN at.amount ELSE 0 END), 0) as expenses
+    FROM (
+      SELECT CURDATE() as date
+      UNION ALL SELECT DATE_SUB(CURDATE(), INTERVAL 1 DAY)
+      UNION ALL SELECT DATE_SUB(CURDATE(), INTERVAL 2 DAY)
+      UNION ALL SELECT DATE_SUB(CURDATE(), INTERVAL 3 DAY)
+      UNION ALL SELECT DATE_SUB(CURDATE(), INTERVAL 4 DAY)
+      UNION ALL SELECT DATE_SUB(CURDATE(), INTERVAL 5 DAY)
+      UNION ALL SELECT DATE_SUB(CURDATE(), INTERVAL 6 DAY)
+    ) d
+    LEFT JOIN accounts_transactions at ON d.date = DATE(at.date) AND (at.toId = ? OR at.fromId = ?)
+    GROUP BY d.date
+    ORDER BY d.date ASC
+    `,
+    [account.id, account.id, account.id, account.id]
+  );
+  
   return {
     balance: account.balance,
-    overview: [],
+    overview,
     transactions: [],
     invoices: [],
   };


### PR DESCRIPTION
Linked to ox_core PR : https://github.com/overextended/ox_core/pull/125

This query create a 7 last days array, if there is no transaction for this day it will return 0 for income and expenses

![image](https://github.com/overextended/ox_banking/assets/11323987/24af67b3-a63b-4471-a7be-c32310a14d8d)
For 990 transactions linked to the account

![image](https://github.com/overextended/ox_banking/assets/11323987/3b6489c3-c97e-4f04-9cf1-69b70ff13061)

