### PR TITLE
fix: display of cash already handled by inventory change

### DIFF
--- a/web/src/layouts/bank/pages/accounts/modals/DepositWithdrawModal.tsx
+++ b/web/src/layouts/bank/pages/accounts/modals/DepositWithdrawModal.tsx
@@ -73,8 +73,6 @@ const DepositWithdrawModal: React.FC<{ account: Account; isDeposit?: boolean }> 
       }
     );
 
-    setCharacter(prev => ({...prev, cash: isDeposit ? prev.cash - amount : prev.cash + amount}))
-
     queryClient.setQueryData(['accounts'], (data: { numberOfPages: number; accounts: Account[] } | undefined) => {
       if (!data) return;
 


### PR DESCRIPTION
This already update char state, so before this PR, it remove money twice on UI
https://github.com/overextended/ox_banking/blob/9cdf0ca94eb6658c37474a42969d04442a245ec9/client/index.ts#L93
