### PR TITLE
fix(monorepo): allow support for a global monorepo

### DIFF
--- a/src/web/package.json
+++ b/src/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ox_banking",
+  "name": "ox_banking_nui",
   "homepage": "web/build",
   "private": true,
   "version": "0.1.0",


### PR DESCRIPTION
using a monorepo structure and tooling such as turborepo causes issues when running commands like `pnpm build` or `pnpm watch` fails due to duplicated package names.