### PR TITLE
chore(monorepo): removal of unused scripts inside web dir

### DIFF
--- a/src/web/package.json
+++ b/src/web/package.json
@@ -4,11 +4,7 @@
   "private": true,
   "version": "0.1.0",
   "scripts": {
-    "start": "vite",
-    "start:game": "vite build --watch",
-    "watch": "vite build --watch",
-    "build": "tsc && vite build",
-    "preview": "vite preview"
+    
   },
   "dependencies": {
 


### PR DESCRIPTION
the scripts inside the nui aren't called and when in use with monorepo tooling it throws errors due to the called packages not being installed