### PR TITLE
fix(web/state): handle undefined default account

### DIFF
--- a/src/web/src/state/accounts/accounts.ts
+++ b/src/web/src/state/accounts/accounts.ts
@@ -45,7 +45,7 @@ const [accountsDataAtom] = atomsWithQuery<{ numberOfPages: number; accounts: Acc
       const defaultAccount = accounts.find((account) => account.isDefault)!;
 
       return {
-        accounts: [defaultAccount, ...accounts.filter((account) => !account.isDefault)],
+        accounts: defaultAccount ? [defaultAccount, ...accounts.filter((account) => !account.isDefault)] : accounts,
         numberOfPages: Math.ceil((accounts.length + 1) / 4),
       };
     },


### PR DESCRIPTION
This pull request fixes a problem where the `defaultAccount` could be undefined and was still added to the list of accounts. The code now checks if the `defaultAccount` exists before adding it.