### PR TITLE
fix(nui): remove unused nui build scripts

### DIFF
--- a/src/web/package.json
+++ b/src/web/package.json
@@ -4,11 +4,7 @@
   "private": true,
   "version": "0.1.0",
   "scripts": {
-    "start": "vite",
-    "start:game": "vite build --watch",
-    "watch": "vite build --watch",
-    "build": "tsc && vite build",
-    "preview": "vite preview"
+
   },
   "dependencies": {
 


### PR DESCRIPTION
these scripts arent used and throw errors when in use inside a monorepo.

these scripts are substituted by web:dev, web:watch in the parent project.

it throws errors due to vite and tsc not being installed globally, which isnt feasible when building a monorepo in a ci pipeline