### PR TITLE
feat(invoices): display actorId details

### DIFF
--- a/src/common/typings/nui.ts
+++ b/src/common/typings/nui.ts
@@ -80,6 +80,8 @@ export type BaseInvoice = {
   message: string;
   amount: number;
   dueDate: number;
+  sentBy?: string;
+  sentAt: number;
 };
 
 export type UnpaidInvoice = BaseInvoice & {
@@ -94,7 +96,5 @@ export type PaidInvoice = BaseInvoice & {
 
 export type SentInvoice = BaseInvoice & {
   type: 'sent';
-  sentBy: string;
-  sentAt: number;
   status: 'paid' | 'sent' | 'overdue';
 };

--- a/src/web/src/layouts/bank/pages/accounts/invoices/modals/PaidInvoiceDetailsModal.tsx
+++ b/src/web/src/layouts/bank/pages/accounts/invoices/modals/PaidInvoiceDetailsModal.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { formatNumber } from '@/utils/formatNumber';
-import { PaidInvoice } from '~/src/common/typings';
 import locales from '@/locales';
 import { formatDate } from '@/utils/formatDate';
+import { formatNumber } from '@/utils/formatNumber';
+import React from 'react';
+import { PaidInvoice } from '~/src/common/typings';
 
 const PaidInvoiceDetailsModal: React.FC<{ invoice: PaidInvoice }> = ({ invoice }) => {
   return (
@@ -10,6 +10,16 @@ const PaidInvoiceDetailsModal: React.FC<{ invoice: PaidInvoice }> = ({ invoice }
       <div>
         <p className="text-muted-foreground text-xs">{locales.invoice_payment_to}</p>
         <p className="text-sm">{invoice.label}</p>
+      </div>
+      {invoice.sentBy && (
+        <div>
+          <p className="text-muted-foreground text-xs">{locales.invoice_details_sent_by}</p>
+          <p className="text-sm">{invoice.sentBy}</p>
+        </div>
+      )}
+      <div>
+        <p className="text-muted-foreground text-xs">{locales.invoice_details_sent_at}</p>
+        <p className="text-sm">{formatDate(invoice.sentAt)}</p>
       </div>
       <div>
         <p className="text-muted-foreground text-xs">{locales.invoice_details_due_by}</p>

--- a/src/web/src/layouts/bank/pages/accounts/invoices/modals/SentInvoiceDetailsModal.tsx
+++ b/src/web/src/layouts/bank/pages/accounts/invoices/modals/SentInvoiceDetailsModal.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { formatNumber } from '@/utils/formatNumber';
-import { SentInvoice } from '~/src/common/typings';
 import locales from '@/locales';
 import { formatDate } from '@/utils/formatDate';
+import { formatNumber } from '@/utils/formatNumber';
+import React from 'react';
+import { SentInvoice } from '~/src/common/typings';
 
 const SentInvoiceDetailsModal: React.FC<{ invoice: SentInvoice }> = ({ invoice }) => {
   return (
@@ -11,10 +11,12 @@ const SentInvoiceDetailsModal: React.FC<{ invoice: SentInvoice }> = ({ invoice }
         <p className="text-muted-foreground text-xs">{locales.invoice_details_sent_to}</p>
         <p className="text-sm">{invoice.label}</p>
       </div>
-      <div>
-        <p className="text-muted-foreground text-xs">{locales.invoice_details_sent_by}</p>
-        <p className="text-sm">{invoice.sentBy}</p>
-      </div>
+      {invoice.sentBy && (
+        <div>
+          <p className="text-muted-foreground text-xs">{locales.invoice_details_sent_by}</p>
+          <p className="text-sm">{invoice.sentBy}</p>
+        </div>
+      )}
       <div>
         <p className="text-muted-foreground text-xs">{locales.invoice_details_sent_at}</p>
         <p className="text-sm">{formatDate(invoice.sentAt)}</p>
@@ -28,7 +30,7 @@ const SentInvoiceDetailsModal: React.FC<{ invoice: SentInvoice }> = ({ invoice }
         <p className="text-sm">{invoice.message}</p>
       </div>
       <div>
-        <p className="text-muted-foreground text-xs">locales.total</p>
+        <p className="text-muted-foreground text-xs">{locales.invoice_total}</p>
         <p className="text-sm">{formatNumber(invoice.amount)}</p>
       </div>
     </div>

--- a/src/web/src/layouts/bank/pages/accounts/invoices/modals/UnpaidInvoiceDetailsModal.tsx
+++ b/src/web/src/layouts/bank/pages/accounts/invoices/modals/UnpaidInvoiceDetailsModal.tsx
@@ -1,3 +1,4 @@
+import locales from '@/locales';
 import { formatDate } from '@/utils/formatDate';
 import { formatNumber } from '@/utils/formatNumber';
 import React from 'react';
@@ -7,19 +8,29 @@ const UnpaidInvoiceDetailsModal: React.FC<{ invoice: UnpaidInvoice }> = ({ invoi
   return (
     <div className="flex flex-col gap-4">
       <div>
-        <p className="text-muted-foreground text-xs">Payment to</p>
+        <p className="text-muted-foreground text-xs">{locales.invoice_details_sent_to}</p>
         <p className="text-sm">{invoice.label}</p>
       </div>
+      {invoice.sentBy && (
+        <div>
+          <p className="text-muted-foreground text-xs">{locales.invoice_details_sent_by}</p>
+          <p className="text-sm">{invoice.sentBy}</p>
+        </div>
+      )}
       <div>
-        <p className="text-muted-foreground text-xs">Due date</p>
+        <p className="text-muted-foreground text-xs">{locales.invoice_details_sent_at}</p>
+        <p className="text-sm">{formatDate(invoice.sentAt)}</p>
+      </div>
+      <div>
+        <p className="text-muted-foreground text-xs">{locales.invoice_details_due_by}</p>
         <p>{formatDate(invoice.dueDate)}</p>
       </div>
       <div>
-        <p className="text-muted-foreground text-xs">Message</p>
+        <p className="text-muted-foreground text-xs">{locales.message}</p>
         <p className="text-sm">{invoice.message}</p>
       </div>
       <div>
-        <p className="text-muted-foreground text-xs">Total</p>
+        <p className="text-muted-foreground text-xs">{locales.invoice_total}</p>
         <p className="text-sm">{formatNumber(invoice.amount)}</p>
       </div>
     </div>


### PR DESCRIPTION
When creating invoices for a group account from a group account, I am passing the actorId as well, which is the player creating the invoice. This is nice to have to view on the invoice details, so players with permissions to view the invoices can see if which player is sending what invoice, this to search for potential abuses and is just nice to have.

This is just visible when actorId is actually something.

![image](https://github.com/user-attachments/assets/40760cbb-55c4-46e3-8734-0180b26bf02b)

This pull request also includes usage of locales for the UnpaidInvoiceDetailsModal component.